### PR TITLE
enable catchAll to catch messages without slash commands

### DIFF
--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'benjick:telegram-bot',
-  version: '0.0.2',
+  version: '1.0.1',
   summary: 'TelegramBot API wrapper - FORK',
   git: 'https://github.com/benjick/meteor-telegram-bot',
   documentation: 'README.md'

--- a/package.js
+++ b/package.js
@@ -1,8 +1,8 @@
 Package.describe({
-  name: 'dcsan:telegram-bot',
-  version: '0.0.1',
+  name: 'benjick:telegram-bot',
+  version: '0.0.2',
   summary: 'TelegramBot API wrapper - FORK',
-  git: 'https://github.com/dcsan/meteor-telegram-bot',
+  git: 'https://github.com/benjick/meteor-telegram-bot',
   documentation: 'README.md'
 });
 

--- a/package.js
+++ b/package.js
@@ -1,8 +1,8 @@
 Package.describe({
-  name: 'benjick:telegram-bot',
-  version: '1.0.0',
-  summary: 'TelegramBot API wrapper',
-  git: 'https://github.com/benjick/meteor-telegram-bot',
+  name: 'dcsan:telegram-bot',
+  version: '0.0.1',
+  summary: 'TelegramBot API wrapper - FORK',
+  git: 'https://github.com/dcsan/meteor-telegram-bot',
   documentation: 'README.md'
 });
 

--- a/telegram-bot.js
+++ b/telegram-bot.js
@@ -7,95 +7,95 @@ TelegramBot.getUpdatesOffset = 0;
 TelegramBot.interval = false;
 
 TelegramBot.parseCommandString = function (msg) {
-    // splits string into an array
-    // and removes the @botname from the command
-    // then returns the array
-    msg = msg.split(' ')
-    msg[0] = msg[0].split('@')[0]
-    return msg;
+	// splits string into an array
+	// and removes the @botname from the command
+	// then returns the array
+	msg = msg.split(' ')
+	msg[0] = msg[0].split('@')[0]
+	return msg;
 }
 
 TelegramBot.poll = function () {
-    var result = TelegramBot.method("getUpdates", {
-        offset: TelegramBot.getUpdatesOffset + 1
-    });
-    TelegramBot.parsePollResult(result.result);
+	var result = TelegramBot.method("getUpdates", {
+		offset: TelegramBot.getUpdatesOffset + 1
+	});
+	TelegramBot.parsePollResult(result.result);
 }
 
 TelegramBot.start = function () {
-    TelegramBot.poll();
-    TelegramBot.interval = Meteor.setInterval(function () {
-        TelegramBot.poll();
-    }, 1000);
+	TelegramBot.poll();
+	TelegramBot.interval = Meteor.setInterval(function () {
+		TelegramBot.poll();
+	}, 1000);
 }
 
 TelegramBot.stop = function () {
-    Meteor.clearInterval(TelegramBot.interval);
+	Meteor.clearInterval(TelegramBot.interval);
 }
 
 TelegramBot.parsePollResult = function (data) {
-    data.map(function (item) {
-        TelegramBot.getUpdatesOffset = item.update_id;
-        var chatId = item.message.chat.id;
-        var from = item.message.from.username;
-        if (msg = item.message.text) {
-            msg = TelegramBot.parseCommandString(msg)
-            var obj = _.find(TelegramBot.triggers, function (obj) {
-                return obj.command == msg[0]
-            })
-            if (obj) {
-                TelegramBot.send(obj.callback(msg, from, item.message), chatId)
-            } else {
-                if (typeof(TelegramBot.catchAll) === 'function') {
-                    TelegramBot.catchAll(item);
-                }
-            }
-        }
-    });
+	data.map(function (item) {
+		TelegramBot.getUpdatesOffset = item.update_id;
+		var chatId = item.message.chat.id;
+		var from = item.message.from.username;
+		if (msg = item.message.text) {
+			msg = TelegramBot.parseCommandString(msg)
+			var obj = _.find(TelegramBot.triggers, function (obj) {
+				return obj.command == msg[0]
+			})
+			if (obj) {
+				TelegramBot.send(obj.callback(msg, from, item.message), chatId)
+			} else {
+				if (typeof(TelegramBot.catchAll) === 'function') {
+					TelegramBot.catchAll(item);
+				}
+			}
+		}
+	});
 }
 
 TelegramBot.requestUrl = function (method) {
-    var token = TelegramBot.token || process.env.TELEGRAM_TOKEN;
-    return TelegramBot.apiBase + token + '/' + method
+	var token = TelegramBot.token || process.env.TELEGRAM_TOKEN;
+	return TelegramBot.apiBase + token + '/' + method
 }
 
 TelegramBot.addListener = function (command, callback) {
-    if (typeof(command) === 'string' && typeof(callback) === 'function') {
-        TelegramBot.triggers.push({
-            command: command,
-            callback: callback
-        })
-        console.log('Added command ' + command);
-    }
-    else {
-        console.log("Error adding command " + command)
-    }
+	if (typeof(command) === 'string' && typeof(callback) === 'function') {
+		TelegramBot.triggers.push({
+			command: command,
+			callback: callback
+		})
+		console.log('Added command ' + command);
+	}
+	else {
+		console.log("Error adding command " + command)
+	}
 }
 
 TelegramBot.method = function (method, object) {
-    var object = object || {};
+	var object = object || {};
 
-    try {
-        var res = HTTP.get(TelegramBot.requestUrl(method), {
-            params: object
-        });
-        if (res.data) {
-            return res.data
-        }
-    }
-    catch (e) {
-        console.log(e)
-    }
+	try {
+		var res = HTTP.get(TelegramBot.requestUrl(method), {
+			params: object
+		});
+		if (res.data) {
+			return res.data
+		}
+	}
+	catch (e) {
+		console.log(e)
+	}
 }
 
 TelegramBot.send = function (msg, chatId) {
-    if (!msg) {
-        return false;
-    }
+	if (!msg) {
+		return false;
+	}
 
-    TelegramBot.method('sendMessage', {
-        chat_id: chatId,
-        text: msg
-    })
+	TelegramBot.method('sendMessage', {
+		chat_id: chatId,
+		text: msg
+	})
 }
 

--- a/telegram-bot.js
+++ b/telegram-bot.js
@@ -6,95 +6,96 @@ TelegramBot.init = false;
 TelegramBot.getUpdatesOffset = 0;
 TelegramBot.interval = false;
 
-TelegramBot.parseCommandString = function(msg) {
-	// splits string into an array 
-	// and removes the @botname from the command
-	// then returns the array
-	msg = msg.split(' ')
-	msg[0] = msg[0].split('@')[0]
-	return msg;
+TelegramBot.parseCommandString = function (msg) {
+    // splits string into an array
+    // and removes the @botname from the command
+    // then returns the array
+    msg = msg.split(' ')
+    msg[0] = msg[0].split('@')[0]
+    return msg;
 }
 
-TelegramBot.poll = function() {
-	var result = TelegramBot.method("getUpdates", {
-		offset: TelegramBot.getUpdatesOffset + 1
-	});
-	TelegramBot.parsePollResult(result.result);
+TelegramBot.poll = function () {
+    var result = TelegramBot.method("getUpdates", {
+        offset: TelegramBot.getUpdatesOffset + 1
+    });
+    TelegramBot.parsePollResult(result.result);
 }
 
-TelegramBot.start = function() {
-	TelegramBot.poll();
-	TelegramBot.interval = Meteor.setInterval(function () {
-		TelegramBot.poll();
-	}, 1000);
+TelegramBot.start = function () {
+    TelegramBot.poll();
+    TelegramBot.interval = Meteor.setInterval(function () {
+        TelegramBot.poll();
+    }, 1000);
 }
 
-TelegramBot.stop = function() {
-	Meteor.clearInterval(TelegramBot.interval);
+TelegramBot.stop = function () {
+    Meteor.clearInterval(TelegramBot.interval);
 }
 
-TelegramBot.parsePollResult = function(data) {
-	data.map(function (item) {
-		TelegramBot.getUpdatesOffset = item.update_id;
-		var chatId = item.message.chat.id;
-		var from = item.message.from.username;
-		if(msg = item.message.text) {
-			msg = TelegramBot.parseCommandString(msg)
-			var obj = _.find(TelegramBot.triggers, function(obj) { return obj.command == msg[0] })
-			if(obj) {
-				TelegramBot.send(obj.callback(msg, from, item.message), chatId)
-			}
-		}
-		else {
-			if(typeof(TelegramBot.catchAll) === 'function') {
-				TelegramBot.catchAll(item);
-			}
-		}
-	});
+TelegramBot.parsePollResult = function (data) {
+    data.map(function (item) {
+        TelegramBot.getUpdatesOffset = item.update_id;
+        var chatId = item.message.chat.id;
+        var from = item.message.from.username;
+        if (msg = item.message.text) {
+            msg = TelegramBot.parseCommandString(msg)
+            var obj = _.find(TelegramBot.triggers, function (obj) {
+                return obj.command == msg[0]
+            })
+            if (obj) {
+                TelegramBot.send(obj.callback(msg, from, item.message), chatId)
+            } else {
+                if (typeof(TelegramBot.catchAll) === 'function') {
+                    TelegramBot.catchAll(item);
+                }
+            }
+        }
+    });
 }
 
-TelegramBot.requestUrl = function(method) {
-	var token = TelegramBot.token || process.env.TELEGRAM_TOKEN;
-	return TelegramBot.apiBase + token + '/' + method
+TelegramBot.requestUrl = function (method) {
+    var token = TelegramBot.token || process.env.TELEGRAM_TOKEN;
+    return TelegramBot.apiBase + token + '/' + method
 }
 
-TelegramBot.addListener = function(command, callback) {
-	if(typeof(command) === 'string' && typeof(callback) === 'function') {
-		TelegramBot.triggers.push({
-			command: command,
-			callback: callback
-		})
-		console.log('Added command ' + command);
-	}
-	else {
-		console.log("Error adding command " + command)
-	}
+TelegramBot.addListener = function (command, callback) {
+    if (typeof(command) === 'string' && typeof(callback) === 'function') {
+        TelegramBot.triggers.push({
+            command: command,
+            callback: callback
+        })
+        console.log('Added command ' + command);
+    }
+    else {
+        console.log("Error adding command " + command)
+    }
 }
 
-TelegramBot.method = function(method, object) {
-	var object = object || {};
+TelegramBot.method = function (method, object) {
+    var object = object || {};
 
-	try {
-		var res = HTTP.get(TelegramBot.requestUrl(method), {
-			params: object
-		});
-		if(res.data) {
-			return res.data
-		}
-	}
-	catch (e) {
-		console.log(e)
-	}
+    try {
+        var res = HTTP.get(TelegramBot.requestUrl(method), {
+            params: object
+        });
+        if (res.data) {
+            return res.data
+        }
+    }
+    catch (e) {
+        console.log(e)
+    }
 }
 
-TelegramBot.send = function(msg, chatId) {
-	if(!msg) {
-		return false;
-	}
+TelegramBot.send = function (msg, chatId) {
+    if (!msg) {
+        return false;
+    }
 
-	TelegramBot.method('sendMessage', {
-		chat_id: chatId,
-		text: msg
-	})
+    TelegramBot.method('sendMessage', {
+        chat_id: chatId,
+        text: msg
+    })
 }
 


### PR DESCRIPTION
related to
https://github.com/benjick/meteor-telegram-bot/issues/2#issuecomment-131512388

I moved the else so that I can just listen to anything
i'm not sure if how you had it was intended, but sending a PR just in case

https://github.com/benjick/meteor-telegram-bot/compare/master...dcsan:master#diff-bbf93bd50fe3430cb93c364ce85173f8R48

i switched back to tabs to match your style but
unfortunately my editor/linter put some extra spaces between function names

also bumped it to 1.0.1

unfortunately a couple of the tests are failing, one looks like a complex NPM package dependency thing at tinytest time, which I'm not sure how to fix. 

![image](https://cloud.githubusercontent.com/assets/514002/9292845/d5d1cf78-43c2-11e5-9ed0-0499c3450a81.png)
