### PR TITLE
Only parsePollResult if the method request succeeded

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+*.versions

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Adds an easy to use Telegram Bot API wrapper.
 
 ## Installation
 
-    meteor add shrmn:telegram-bot
+    meteor add benjick:telegram-bot
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Adds an easy to use Telegram Bot API wrapper.
 
 ## Installation
 
-    meteor add benjick:telegram-bot
+    meteor add shrmn:telegram-bot
 
 ## Usage
 
@@ -79,30 +79,30 @@ This means you can get the arguments in a nice way. This is done when a webHook 
 
 ```js
 if (Meteor.isServer) {
-  Meteor.startup(function () {
-    // set our token
-    TelegramBot.token = '123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11';
-    TelegramBot.start(); // start the bot
-    // add a listener for '/test'
-    TelegramBot.addListener('/test', function(command) {
-    // command will contain the entire command in an array where command[0] is the command.
-    // In this case '/test'. Each argument will follow.
-      if(!command[1]) { // if no arguments
-        return false
-        // if you return false the bot wont answer
-      }
-      // command[1] will be the first argument, command[2] the second etc
-      // below the bot will reply with 'test: hi' if you sent him /test hi
-      return "test: " + command[1]
-    })
-  });
+	Meteor.startup(function () {
+	// set our token
+	TelegramBot.token = '123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11';
+	TelegramBot.start(); // start the bot
+	// add a listener for '/test'
+	TelegramBot.addListener('/test', function(command) {
+		// command will contain the entire command in an array where command[0] is the command.
+		// In this case '/test'. Each argument will follow.
+		if(!command[1]) { // if no arguments
+			return false
+			// if you return false the bot wont answer
+		}
+		// command[1] will be the first argument, command[2] the second etc
+		// below the bot will reply with 'test: hi' if you sent him /test hi
+		return "test: " + command[1]
+		});
+	});
 }
 ```
 
 ```js
 // You can also get the username via the second argument
 TelegramBot.addListener('/hi', function(command, username) {
-  return "hi @" + username
+	return "hi @" + username
 })
 ```
 
@@ -110,11 +110,11 @@ Listing all commands:
 
 ```js
 TelegramBot.addListener('/help', function(command) {
-  var msg = "I have the following commands loaded:\n";
-  TelegramBot.triggers.text.forEach(function (post) {
-    msg = msg + "- " + post.command + "\n";
-  });
-  return msg;
+	var msg = "I have the following commands loaded:\n";
+	TelegramBot.triggers.text.forEach(function (post) {
+	msg = msg + "- " + post.command + "\n";
+	});
+	return msg;
 })
 ```
 
@@ -122,15 +122,13 @@ Example using other types than the default
 
 ```js
 TelegramBot.addListener('incoming_document', function(c, u, o) {
-  TelegramBot.send('Got a file with ID ' + o.document.file_id, o.chat.id);
-  var file = TelegramBot.method('getFile', {
-    file_id: o.document.file_id,
-  }).result.file_path;
-  // actually don't do this because it will expose
-  // your Telegram API key
-  TelegramBot.send('Download the file at https://api.telegram.org/file/bot' + TelegramBot.token + '/' + file, o.chat.id);
+	TelegramBot.send('Got a file with ID ' + o.document.file_id, o.chat.id);
+	var file = TelegramBot.method('getFile', {
+		file_id: o.document.file_id
+	}).result.file_path;
+	// Don't do this in production because it will expose your Telegram Bot's API key
+	TelegramBot.send('Download the file at https://api.telegram.org/file/bot' + TelegramBot.token + '/' + file, o.chat.id);
 }, 'document');
-
 ```
 
 #### Overriding listeners
@@ -139,10 +137,10 @@ You can do what you want in the callback for the listener really. For example ca
 
 ```js
 TelegramBot.addListener('/geo', function(command, username, original) {
-  TelegramBot.method('sendLocation',{
-    chat_id: original.chat.id,
-    latitude: 59.329323,
-    longitude: 18.068581
-  })
-})
+	TelegramBot.method('sendLocation',{
+		chat_id: original.chat.id,
+		latitude: 59.329323,
+		longitude: 18.068581
+	});
+});
 ```

--- a/README.md
+++ b/README.md
@@ -68,9 +68,9 @@ Takes the incoming message, strips the *@botname* out if any (used in channels w
 
 For example:
 ```js
-var msg = "/test@thisbot is fun"
+var msg = "/test@thisbot is fun";
 msg = TelegramBot.parseCommandString(msg);
-console.log(msg) // [ '/test', 'is', 'fun' ]
+console.log(msg); // [ '/test', 'is', 'fun' ]
 ```
 
 This means you can get the arguments in a nice way. This is done when a webHook is recieved.
@@ -78,8 +78,8 @@ This means you can get the arguments in a nice way. This is done when a webHook 
 ### A few examples
 
 ```js
-if (Meteor.isServer) {
-	Meteor.startup(function () {
+if(Meteor.isServer) {
+	Meteor.startup(function() {
 	// set our token
 	TelegramBot.token = '123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11';
 	TelegramBot.start(); // start the bot
@@ -115,7 +115,7 @@ TelegramBot.addListener('/help', function(command) {
 	msg = msg + "- " + post.command + "\n";
 	});
 	return msg;
-})
+});
 ```
 
 Example using other types than the default

--- a/package.js
+++ b/package.js
@@ -1,8 +1,8 @@
 Package.describe({
-  name: 'benjick:telegram-bot',
-  version: '1.1.0',
+  name: 'shrmn:telegram-bot',
+  version: '1.1.1',
   summary: 'TelegramBot API wrapper',
-  git: 'https://github.com/benjick/meteor-telegram-bot',
+  git: 'https://github.com/ShrmnK/meteor-telegram-bot',
   documentation: 'README.md'
 });
 

--- a/package.js
+++ b/package.js
@@ -1,8 +1,8 @@
 Package.describe({
-  name: 'shrmn:telegram-bot',
-  version: '1.1.1',
+  name: 'benjick:telegram-bot',
+  version: '1.1.0',
   summary: 'TelegramBot API wrapper',
-  git: 'https://github.com/ShrmnK/meteor-telegram-bot',
+  git: 'https://github.com/benjick/meteor-telegram-bot',
   documentation: 'README.md'
 });
 

--- a/telegram-bot.js
+++ b/telegram-bot.js
@@ -20,7 +20,9 @@ TelegramBot.poll = function() {
 		offset: TelegramBot.getUpdatesOffset + 1,
 	});
 	
-	if(result)
+	// Additional check for duplicate poll data
+	// Also skips the call to parsePollResults if there were no results
+	if(result && result.result.length > 0 && TelegramBot.getUpdatesOffset !==  _.last(result.result).update_id)
 		TelegramBot.parsePollResult(result.result);
 }
 

--- a/telegram-bot.js
+++ b/telegram-bot.js
@@ -19,7 +19,9 @@ TelegramBot.poll = function() {
 	const result = TelegramBot.method("getUpdates", {
 		offset: TelegramBot.getUpdatesOffset + 1,
 	});
-	TelegramBot.parsePollResult(result.result);
+	
+	if(result)
+		TelegramBot.parsePollResult(result.result);
 }
 
 TelegramBot.start = function() {
@@ -50,7 +52,7 @@ TelegramBot.parsePollResult = function(data) {
 			if(typeof(TelegramBot.triggers[type]) !== 'undefined') {
 				TelegramBot.triggers[type].map(trigger => {
 					trigger.callback('N/A', from, message);
-				})
+				});
 			}
 		}
 	});
@@ -58,7 +60,7 @@ TelegramBot.parsePollResult = function(data) {
 
 TelegramBot.requestUrl = function(method) {
 	const token = TelegramBot.token || process.env.TELEGRAM_TOKEN;
-	return TelegramBot.apiBase + token + '/' + method
+	return TelegramBot.apiBase + token + '/' + method;
 }
 
 TelegramBot.addListener = function(command, callback, type = 'text') {
@@ -69,25 +71,27 @@ TelegramBot.addListener = function(command, callback, type = 'text') {
 		TelegramBot.triggers[type].push({
 			command: command,
 			callback: callback
-		})
+		});
 		console.log('Added command ' + command);
 	}
 	else {
-		console.log("Error adding command " + command)
+		console.log("Error adding command " + command);
 	}
 }
 
 TelegramBot.method = function(method, object = {}) {
 	try {
 		const res = HTTP.get(TelegramBot.requestUrl(method), {
-			params: object,
+			params: object
 		});
 		if(res.data) {
 			return res.data;
 		}
 	}
 	catch (e) {
-		console.log(e)
+		console.log("Error in polling:");
+		console.log(e);
+		return false;
 	}
 }
 
@@ -99,5 +103,5 @@ TelegramBot.send = function(msg, chatId) {
 	TelegramBot.method('sendMessage', {
 		chat_id: chatId,
 		text: msg
-	})
+	});
 }


### PR DESCRIPTION
I had an issue while developing a bot locally which caused duplicate commands along with my console window flooded with errors about how there was no result to parse in the `setInterval`. (I was on a weak wifi signal and this caused almost half my packets to be dropped)

Investigating further, I realised that any `HTTP.get` errors would only call a `console.log` with the exception, but `parsePollResult` will still be called. 

I added a quick check `if(result)` before calling parsePollResult and it fixed all my above issues.

EDIT: Also added 2 more checks which prevent calling parsePollResult if there are no updates, and to check if there was duplicate poll data

Also took the chance to format the readme and add missing semicolons.
