### PR TITLE
Markdown Support

### DIFF
--- a/telegram-bot.js
+++ b/telegram-bot.js
@@ -102,8 +102,15 @@ TelegramBot.send = function(msg, chatId) {
 		return false;
 	}
 
-	TelegramBot.method('sendMessage', {
-		chat_id: chatId,
-		text: msg
-	});
+	if(markdown)
+		TelegramBot.method('sendMessage', {
+			chat_id: chatId,
+			text: msg,
+			parse_mode: 'Markdown'
+		});
+	else
+		TelegramBot.method('sendMessage', {
+			chat_id: chatId,
+			text: msg
+		});
 }

--- a/telegram-bot.js
+++ b/telegram-bot.js
@@ -97,7 +97,7 @@ TelegramBot.method = function(method, object = {}) {
 	}
 }
 
-TelegramBot.send = function(msg, chatId) {
+TelegramBot.send = function(msg, chatId, markdown) {
 	if(!msg) {
 		return false;
 	}


### PR DESCRIPTION
Adds third boolean `markdown` argument to `TelegramBot.send` to indicate if the given message should be formatted in Markdown.
