### PR TITLE
fix bug with bot commands not being recognised as text messages (and …

### DIFF
--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'benjick:telegram-bot',
-  version: '1.2.1',
+  version: '1.2.2',
   summary: 'TelegramBot API wrapper',
   git: 'https://github.com/benjick/meteor-telegram-bot',
   documentation: 'README.md'

--- a/telegram-bot.js
+++ b/telegram-bot.js
@@ -44,7 +44,10 @@ TelegramBot.parsePollResult = function(data) {
 		TelegramBot.getUpdatesOffset = item.update_id;
 
 		const message = item.message;
-		const type = Object.keys(message).pop();
+		keys = Object.keys(message);
+		if (keys[keys.length-1] == "entities")
+			keys.pop();
+		const type = keys.pop();
 		const from = item.message.from.username;
 		const chatId = message.chat.id;
 		var is_conversation = false;


### PR DESCRIPTION
…hence not getting handled) with the introduction of telegram bot api 2.0 and the addition of 'entities' field to the message object
