### PR TITLE
Better inline keyboard support

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Without the last 3 optional parameters, it is equivalent to `TelegramBot.method(
 Additional optional parameters:
 - markdown (optional): whether the message should be parsed with Markdown syntax
 - reply_markup (optional): used to send custom (inline) keyboards
-- replyCallback (optional): used to evaluate the result of a custom (inline) keyboard
+- replyCallback (optional): used to evaluate the result of a custom (inline) keyboard. If the replyCallback returns _true_, then the callback itself can be used several times (important for inline keyboards)
 
 #### TelegramBot.triggers = []
 

--- a/telegram-bot.js
+++ b/telegram-bot.js
@@ -92,7 +92,7 @@ TelegramBot.parsePollResult = data => {
 			const callback = TelegramBot.callbacks[chatId][messageId];
 
 			if (callback) {
-				callback(callback_query.data);
+				callback(callback_query.data, chatId, messageId);
 
 				delete TelegramBot.callbacks[chatId][messageId];
 			}

--- a/telegram-bot.js
+++ b/telegram-bot.js
@@ -92,9 +92,8 @@ TelegramBot.parsePollResult = data => {
 			const callback = TelegramBot.callbacks[chatId][messageId];
 
 			if (callback) {
-				callback(callback_query.data, chatId, messageId);
-
-				delete TelegramBot.callbacks[chatId][messageId];
+				if(!callback(callback_query.data, chatId, messageId))
+					delete TelegramBot.callbacks[chatId][messageId];
 			}
 		}
 	});


### PR DESCRIPTION
- TelegramBot.send() replyCallback-argument now gets the original message
- If replyCallback returns _true_, then the callback can be reused

``` javascript
replyCallback = function(data, original) {
  const chat_id = original.message.chat.id;
  const message_id = original.message.message_id;

  return true; // this callback will remain in TelegramBot-callbacks-object
};
TelegramBot.send(message, chatId, markdown, reply_markup, replyCallback);
```
